### PR TITLE
Allow targeting temporal or spatial Wan modules for LoRA

### DIFF
--- a/examples/wan_14b_min_vram.toml
+++ b/examples/wan_14b_min_vram.toml
@@ -42,6 +42,8 @@ timestep_sample_method = 'logit_normal'
 type = 'dora'
 rank = 32
 dtype = 'bfloat16'
+# Optionally limit LoRA to only 'temporal' or 'spatial' modules.
+# target_parts = 'temporal'
 
 [optimizer]
 type = 'AdamW8bitKahan'

--- a/models/base.py
+++ b/models/base.py
@@ -161,14 +161,15 @@ class BasePipeline:
     def get_text_encoders(self):
         raise NotImplementedError()
 
-    def configure_adapter(self, adapter_config):
-        target_linear_modules = set()
-        for name, module in self.transformer.named_modules():
-            if module.__class__.__name__ not in self.adapter_target_modules:
-                continue
-            for full_submodule_name, submodule in module.named_modules(prefix=name):
-                if isinstance(submodule, nn.Linear):
-                    target_linear_modules.add(full_submodule_name)
+    def configure_adapter(self, adapter_config, target_linear_modules=None):
+        if target_linear_modules is None:
+            target_linear_modules = set()
+            for name, module in self.transformer.named_modules():
+                if module.__class__.__name__ not in self.adapter_target_modules:
+                    continue
+                for full_submodule_name, submodule in module.named_modules(prefix=name):
+                    if isinstance(submodule, nn.Linear):
+                        target_linear_modules.add(full_submodule_name)
         target_linear_modules = list(target_linear_modules)
 
         adapter_type = adapter_config['type']


### PR DESCRIPTION
## Summary
- allow BasePipeline.configure_adapter to accept preset targets
- add WanPipeline option to limit LoRA to temporal or spatial modules
- document new adapter option in Wan example config

## Testing
- `pytest` *(fails: the following arguments are required: --input)*

------
https://chatgpt.com/codex/tasks/task_e_689c26edff408331bad7777ca219eb58